### PR TITLE
FIX: Repack to the correct output destination path

### DIFF
--- a/firmware/workspace/repack.sh
+++ b/firmware/workspace/repack.sh
@@ -23,4 +23,4 @@ echo "Detaching $DISKNAME"
 hdiutil detach "$DISKNAME"
 
 echo "Embedding GPT image to $2"
-dd if="$3/gpt.img" of="$1" bs=1024 seek=48 status=progress conv=notrunc
+dd if="$3/gpt.img" of="$2" bs=1024 seek=48 status=progress conv=notrunc


### PR DESCRIPTION
Noticed the current shell script overwrites the *[original.bin]* argument file, which is both confusing and undesirable.

P.S. The code and the guide works for PHYEE F7805C and its 8MB EN25QH64A flash chip.